### PR TITLE
Add integration tests with Minikube

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,16 @@
 language: go
 go:
-  - 1.9.x
   - 1.10.x
 
+sudo: required
+
+env:
+- CHANGE_MINIKUBE_NONE_USER=true
+
 before_script:
-  - go get github.com/hashicorp/consul && go install github.com/hashicorp/consul
+- go get github.com/hashicorp/consul && go install github.com/hashicorp/consul
+- scripts/install_local_k8s.sh
+
+script:
+- make
+- make integration-test

--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,6 @@ lint-deps:
 
 test:
 	go test -v -cover ./...
+
+integration-test:
+	scripts/integration_test.sh

--- a/examples/service-for-dev.yaml
+++ b/examples/service-for-dev.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
   - name: myservice-with-hooks-container
-    image: python:2
+    image: golang:1.10.0-stretch
     command: ["python", "-m", "SimpleHTTPServer", "8080"]
     env:
     - name: KUBERNETES_POD_NAME

--- a/scripts/install_local_k8s.sh
+++ b/scripts/install_local_k8s.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+CHANGE_MINIKUBE_NONE_USER=true
+
+# download and install kubectl, which is a requirement of minikube
+curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.8.0/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+
+# download and install minikube
+curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+
+# start minikube with none driver (it setups localkube on the host)
+sudo minikube start --vm-driver=none --kubernetes-version=v1.8.0
+
+# update kubeconfig
+minikube update-context
+
+# wait for Kubernetes to be up and ready
+JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'
+until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done

--- a/scripts/integration_test.sh
+++ b/scripts/integration_test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+sudo mkdir /hooks
+sudo cp build/consul-registration-hook /hooks
+
+echo "Starting myservice-pod..."
+kubectl create -f examples/service-with-consul-lifecycle-hooks.yaml
+
+until kubectl get pods | tee | grep Running
+do
+  echo "Waiting for myservice-pod to start successfully..."
+  kubectl describe pod myservice-pod
+  sleep 30
+done
+
+kubectl exec -it myservice-pod -- curl -v --fail http://localhost:8500/v1/catalog/service/myservice | grep myservice


### PR DESCRIPTION
This commit adds a simple integration test on Kubernetes cluster started with Minikube. It will create a pod with simple Python application and Consul agent in development mode. Then it checks if hook registers service with desired name.