### PR TITLE
jiRegister by ACL

### DIFF
--- a/cmd/consul-registration-hook/main.go
+++ b/cmd/consul-registration-hook/main.go
@@ -12,13 +12,15 @@ import (
 	"github.com/allegro/consul-registration-hook/k8s"
 )
 
+var consulAclFileFlag = "consul-acl-file"
+
 var commands = []cli.Command{
 	{
 		Name:  "register",
 		Usage: "register service into Consul discovery service",
 		Subcommands: []cli.Command{
 			{
-				Name:  "mesos",
+				Name: "mesos",
 				Usage: "register using data from Mesos Agent API",
 				Action: func(c *cli.Context) error {
 					return errors.New("not supported yet")
@@ -34,7 +36,8 @@ var commands = []cli.Command{
 					if err != nil {
 						return err
 					}
-					agent := consul.NewAgent()
+					aclTokenFile := c.Parent().Parent().String(consulAclFileFlag)
+					agent := consul.NewAgent(aclTokenFile)
 					return agent.Register(services)
 				},
 			},
@@ -61,7 +64,8 @@ var commands = []cli.Command{
 					if err != nil {
 						return err
 					}
-					agent := consul.NewAgent()
+					aclTokenFile := c.Parent().Parent().String(consulAclFileFlag)
+					agent := consul.NewAgent(aclTokenFile)
 					return agent.Deregister(services)
 				},
 			},
@@ -71,6 +75,12 @@ var commands = []cli.Command{
 
 func main() {
 	app := cli.NewApp()
+	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:  consulAclFileFlag,
+			Usage: "language for the greeting",
+		},
+	}
 	app.Name = "consul-registration-hook"
 	app.Description = "Hook that can be used for synchronous registration and deregistration in Consul discovery service on Kubernetes or Mesos cluster with Allegro executor"
 	app.Usage = ""

--- a/consul/agent_test.go
+++ b/consul/agent_test.go
@@ -8,7 +8,21 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"os"
 )
+
+func TestGetsConsulACLToken(t *testing.T) {
+	actualToken := getToken("testdata/consul-acl-token.txt")
+	expectedToken := "testToken"
+	require.Equal(t, expectedToken, actualToken)
+}
+
+func TestGetsConsulACLTokenFromEnvironmentVariable(t *testing.T) {
+	os.Setenv(consulAclTokenEnv, "nonStandardToken")
+	actualToken := getToken("")
+	expectedToken := "nonStandardToken"
+	require.Equal(t, expectedToken, actualToken)
+}
 
 func TestIfRegistersServiceInConsul(t *testing.T) {
 	service := ServiceInstance{

--- a/consul/testdata/consul-acl-token.txt
+++ b/consul/testdata/consul-acl-token.txt
@@ -1,0 +1,1 @@
+testToken

--- a/examples/bootstrap-acl.sh
+++ b/examples/bootstrap-acl.sh
@@ -1,0 +1,9 @@
+ACL_TOKEN_FILE=$1
+ACL_AGENT_TOKEN=$(cat $ACL_TOKEN_FILE)
+
+apk update
+apk add jq
+
+MASTER_TOKEN=mastertoken
+curl --request PUT --header "X-Consul-Token: $MASTER_TOKEN" --data  '{ "ID": "testtoken", "Name": "Agent Token", "Type": "client", "Rules": "node \"\" { policy = \"write\" } service \"\" { policy = \"write\" }" }' http://127.0.0.1:8500/v1/acl/create | jq '.ID'
+curl --request PUT --header "X-Consul-Token: $MASTER_TOKEN" --data "{\"Token\": $AGENT_ACL_TOKEN}" http://127.0.0.1:8500/v1/agent/token/acl_agent_token

--- a/examples/consul-acl.conf.json
+++ b/examples/consul-acl.conf.json
@@ -1,0 +1,6 @@
+{
+  "acl_master_token": "mastertoken",
+  "acl_datacenter": "dc0",
+  "acl_default_policy": "deny",
+  "acl_down_policy": "extend-cache"
+}

--- a/examples/daemonset-with-acl-bootstrapping.yaml
+++ b/examples/daemonset-with-acl-bootstrapping.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: consul-agent
+spec:
+  selector:
+    matchLabels:
+      name: consul-agent
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: consul-agent
+    spec:
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      containers:
+      - name: consul-agent
+        image: "consul:0.9.3"
+        env:
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+        args:
+          - "agent"
+          - "-dev"
+          - "-advertise=$(HOST_IP)"
+          - "-bind=0.0.0.0"
+          - "-client=0.0.0.0"
+          - "-domain=cluster.local"
+          - "-config-file" 
+          - "/hooks/examples/consul-acl.conf.json"
+          - "-datacenter=dc0"
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/sh", "-x", "/hooks/examples/bootstrap-acl.sh", "/consul-acl/token"]
+        volumeMounts:
+            - name: daemon-agent-data
+              mountPath: /consul/data
+            - name: hooks
+              mountPath: /hooks
+            - name: consul-acl
+              mountPath: /consul-acl/
+        ports:
+          - containerPort: 8500
+            hostPort: 8500
+            name: ui-port
+      volumes:
+      - name: daemon-agent-data
+        hostPath:
+          path: /var/lib/consul
+          type: DirectoryOrCreate
+      - name: hooks
+        hostPath:
+          path: /hooks
+      - name: consul-acl
+        secret:
+          secretName: consul-acl
+          items:
+          - key: agent-token
+            path: token
+            mode: 511

--- a/examples/secret-for-consul-agent.yaml
+++ b/examples/secret-for-consul-agent.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: consul-acl
+type: Opaque
+data:
+  agent-token: dGVzdHRva2Vu

--- a/examples/service-with-consul-lifecycle-hooks-and-acl-support.yaml
+++ b/examples/service-with-consul-lifecycle-hooks-and-acl-support.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myservice-pod
+  labels:
+    consul: myservice
+spec:
+  containers:
+  - name: myservice-with-hooks-container
+    image: python:2
+    command: ["python", "-m", "SimpleHTTPServer", "8080"]
+    env:
+    - name: KUBERNETES_POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: KUBERNETES_POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.hostIP
+    ports:
+    - containerPort: 8080
+    volumeMounts:
+    - name: hooks
+      mountPath: /hooks
+    - name: consul-acl
+      mountPath: /consul-acl
+    lifecycle:
+       postStart:
+         exec:
+           command: ["/bin/sh", "-c", "/hooks/consul-registration-hook --consul-acl-file /consul-acl/token register k8s"]
+       preStop:
+         exec:
+           command: ["/bin/sh", "-c", "/hooks/consul-registration-hook --consul-acl-file /consul-acl/token deregister k8s"]
+  volumes:
+  - name: hooks
+    hostPath:
+      path: /hooks
+  - name: consul-acl
+    secret:
+      secretName: consul-acl
+      items:
+      - key: agent-token
+        path: token
+        mode: 511


### PR DESCRIPTION
Add Examples and pass token for deregister.

We want consul-registration-hook to support consul acl system.
Preferably tokens are passed from secrets api by file or as a fallback by environment variable.