### PR TITLE
Change Consul service ID format

### DIFF
--- a/consul/agent.go
+++ b/consul/agent.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/consul/api"
 )
 
+const defaultDeregisterCriticalServiceAfter = "60m"
+
 // CheckType is a health check type.
 type CheckType string
 
@@ -58,6 +60,7 @@ func (a *Agent) Register(services []ServiceInstance) error {
 			check = &api.AgentServiceCheck{
 				Interval: service.Check.Interval.String(),
 				Timeout:  service.Check.Timeout.String(),
+				DeregisterCriticalServiceAfter: defaultDeregisterCriticalServiceAfter,
 			}
 
 			switch service.Check.Type {

--- a/k8s/provider.go
+++ b/k8s/provider.go
@@ -66,13 +66,14 @@ func (p *ServiceProvider) Get(ctx context.Context) ([]consul.ServiceInstance, er
 
 	// TODO(medzin): Allow to specify which containers and ports will be registered
 	container := pod.Spec.Containers[0]
-	port := int(*container.Ports[0].HostPort)
+	host := pod.GetStatus().GetPodIP()
+	port := int(*container.Ports[0].ContainerPort)
 
 	service := consul.ServiceInstance{
-		ID:    fmt.Sprintf("%s_%s_%s_%d", podName, podName, *container.Name, port),
+		ID:    fmt.Sprintf("%s_%d", host, port),
 		Name:  serviceName,
-		Host:  os.Getenv("KUBERNETES_SERVICE_HOST"),
-		Port:  int(*container.Ports[0].HostPort),
+		Host:  host,
+		Port:  port,
 		Check: ConvertToConsulCheck(container.LivenessProbe),
 	}
 


### PR DESCRIPTION
Use IP + port as service ID during registration and add default
DeregisterCriticalServiceAfter check value, so Consul will deregister
pods that are already terminated and hook failed to fire.