### PR TITLE
Force go_import_path for Travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ go:
 
 sudo: required
 
+go_import_path: github.com/allegro/consul-registration-hook
+
 env:
   - CHANGE_MINIKUBE_NONE_USER=true
 


### PR DESCRIPTION
This allows for testing of forked repositories.