### PR TITLE
Add pod name and namespace as consul labels

### DIFF
--- a/k8s/provider.go
+++ b/k8s/provider.go
@@ -12,9 +12,11 @@ import (
 )
 
 const (
-	consulLabelKey     = "consul"
-	podNamespaceEnvVar = "KUBERNETES_POD_NAMESPACE"
-	podNameEnvVar      = "KUBERNETES_POD_NAME"
+	consulLabelKey                  = "consul"
+	podNamespaceEnvVar              = "KUBERNETES_POD_NAMESPACE"
+	podNameEnvVar                   = "KUBERNETES_POD_NAME"
+	consulPodNameLabelTemplate      = "k8sPodName: %s"
+	consulPodNamespaceLabelTemplate = "k8sPodNamespace: %s"
 )
 
 // Client is an interface for client to Kubernetes API.
@@ -75,6 +77,11 @@ func (p *ServiceProvider) Get(ctx context.Context) ([]consul.ServiceInstance, er
 		Host:  host,
 		Port:  port,
 		Check: ConvertToConsulCheck(container.LivenessProbe, host),
+	}
+
+	if podName != "" && podNamespace != "" {
+		service.Tags = append(service.Tags, fmt.Sprintf(consulPodNameLabelTemplate, podName))
+		service.Tags = append(service.Tags, fmt.Sprintf(consulPodNamespaceLabelTemplate, podNamespace))
 	}
 
 	labels := pod.GetMetadata().GetLabels()

--- a/scripts/integration_test.sh
+++ b/scripts/integration_test.sh
@@ -15,4 +15,6 @@ do
   sleep 30
 done
 
-kubectl exec -it myservice-pod -- curl -v --fail http://localhost:8500/v1/catalog/service/myservice | grep myservice
+RESULT=$(kubectl exec -it myservice-pod -- curl -v --fail http://localhost:8500/v1/catalog/service/myservice)
+echo $RESULT | grep myservice
+echo $RESULT | grep "k8sPodNamespace: default"


### PR DESCRIPTION
This adds the pod namespaces and name as a label, to allow for consuming this information later on.