### PR TITLE
Add failure domain info as tags to service

### DIFF
--- a/k8s/provider.go
+++ b/k8s/provider.go
@@ -63,11 +63,10 @@ func (c *defaultClient) GetFailureDomainTags(ctx context.Context, pod *corev1.Po
 		}
 	}
 
-	if len(tags) > 0 {
-		return tags, nil
-	} else {
+	if len(tags) < 1 {
 		return nil, fmt.Errorf("failure domain labels don't exist")
 	}
+	return tags, nil
 }
 
 // ServiceProvider is responsible for providing services that should be registered

--- a/k8s/provider.go
+++ b/k8s/provider.go
@@ -44,7 +44,6 @@ func (c *defaultClient) GetPod(ctx context.Context, namespace, name string) (*co
 	return pod, nil
 }
 
-
 func (c *defaultClient) GetFailureDomainTags(ctx context.Context, pod *corev1.Pod) ([]string, error) {
 	client, err := k8s.NewInClusterClient()
 	if err != nil {
@@ -58,7 +57,7 @@ func (c *defaultClient) GetFailureDomainTags(ctx context.Context, pod *corev1.Po
 	labels := node.GetMetadata().GetLabels()
 	var tags []string
 	for k, v := range labels {
-		if strings.Contains(k, "failure-domain.beta.kubernetes.io" ) {
+		if strings.Contains(k, "failure-domain.beta.kubernetes.io") {
 			tags = append(tags, fmt.Sprintf("%s:%s", strings.Split(k, "/")[1], v))
 		}
 	}

--- a/k8s/provider.go
+++ b/k8s/provider.go
@@ -3,7 +3,9 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
+	"strings"
 
 	"github.com/ericchiang/k8s"
 	corev1 "github.com/ericchiang/k8s/apis/core/v1"
@@ -21,6 +23,8 @@ const (
 type Client interface {
 	// GetPod returns current pod data.
 	GetPod(ctx context.Context, namespace, name string) (*corev1.Pod, error)
+	// GetFailureDomainTags returns current failure domain for pod
+	GetFailureDomainTags(ctx context.Context, pod *corev1.Pod) ([]string, error)
 }
 
 type defaultClient struct {
@@ -38,6 +42,32 @@ func (c *defaultClient) GetPod(ctx context.Context, namespace, name string) (*co
 	}
 
 	return pod, nil
+}
+
+
+func (c *defaultClient) GetFailureDomainTags(ctx context.Context, pod *corev1.Pod) ([]string, error) {
+	client, err := k8s.NewInClusterClient()
+	if err != nil {
+		return nil, fmt.Errorf("unable to create k8s client: %s", err)
+	}
+
+	node := &corev1.Node{}
+	if err := client.Get(ctx, "", pod.GetSpec().GetNodeName(), node); err != nil {
+		return nil, fmt.Errorf("unable to get node data from API: %s", err)
+	}
+	labels := node.GetMetadata().GetLabels()
+	var tags []string
+	for k, v := range labels {
+		if strings.Contains(k, "failure-domain.beta.kubernetes.io" ) {
+			tags = append(tags, fmt.Sprintf("%s:%s", strings.Split(k, "/")[1], v))
+		}
+	}
+
+	if len(tags) > 0 {
+		return tags, nil
+	} else {
+		return nil, fmt.Errorf("failure domain labels don't exist")
+	}
 }
 
 // ServiceProvider is responsible for providing services that should be registered
@@ -75,6 +105,13 @@ func (p *ServiceProvider) Get(ctx context.Context) ([]consul.ServiceInstance, er
 		Host:  host,
 		Port:  port,
 		Check: ConvertToConsulCheck(container.LivenessProbe, host),
+	}
+
+	failureDomainTags, err := client.GetFailureDomainTags(ctx, pod)
+	if err != nil {
+		log.Printf("Won't include failure domain data in registration: %s", err)
+	} else {
+		service.Tags = append(service.Tags, failureDomainTags...)
 	}
 
 	labels := pod.GetMetadata().GetLabels()

--- a/k8s/provider_test.go
+++ b/k8s/provider_test.go
@@ -58,6 +58,8 @@ func TestIfReturnsServiceToRegisterIfAbleToCallKubernetesAPI(t *testing.T) {
 	client := &MockClient{}
 	client.On("GetPod", context.Background(), "", "").
 		Return(pod, nil).Once()
+	client.On("GetFailureDomainTags", context.Background(), pod).
+		Return(nil, nil).Once()
 
 	provider := ServiceProvider{
 		Client: client,
@@ -89,6 +91,9 @@ func TestIfConvertsLabelsToConsulTags(t *testing.T) {
 	client := &MockClient{}
 	client.On("GetPod", context.Background(), "", "").
 		Return(pod, nil).Once()
+	client.On("GetFailureDomainTags", context.Background(), pod).
+		Return(nil, nil).Once()
+
 
 	provider := ServiceProvider{
 		Client: client,
@@ -104,6 +109,7 @@ func TestIfConvertsLabelsToConsulTags(t *testing.T) {
 	assert.Len(t, service.Tags, 1)
 	assert.Contains(t, service.Tags, "test-tag")
 }
+
 
 func testPod() *corev1.Pod {
 	return &corev1.Pod{
@@ -131,4 +137,13 @@ func (c *MockClient) GetPod(ctx context.Context, namespace, name string) (*corev
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(*corev1.Pod), args.Error(1)
+}
+
+func (c *MockClient) GetFailureDomainTags(ctx context.Context, pod *corev1.Pod) ([]string, error) {
+	args := c.Called(ctx, pod)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).([]string), args.Error(1)
 }


### PR DESCRIPTION
Adds cloud region and zone information from the node where the Pod is running as labels in consul if available, for consuming in external systems and easy filtering by availability zone.