### PR TITLE
Use podName instead od IP/Host for ID when registering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ OS        := $(shell go env GOOS)
 BUILD_DIR := build
 LDFLAGS   := -X main.version=$(VERSION)
 
+CURRENT_DIR = $(shell pwd)
+BIN = $(CURRENT_DIR)/bin
 THIS_FILE := $(lastword $(MAKEFILE_LIST))
 .PHONY: all build build-linux package clean lint lint-deps test integration-test
 
@@ -25,11 +27,12 @@ clean:
 	rm -rf $(BUILD_DIR)
 
 lint: lint-deps
-	golangci-lint run --config=golangcilinter.yaml ./...
+	$(BIN)/golangci-lint --version
+	$(BIN)/golangci-lint run --config=golangcilinter.yaml ./...
 
 lint-deps:
 	@which golangci-lint > /dev/null || \
-		(go get -u github.com/golangci/golangci-lint/cmd/golangci-lint)
+		(curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(BIN) v1.30.0)
 
 test:
 	go test -v -coverprofile=coverage.txt -covermode=atomic ./...

--- a/k8s/provider.go
+++ b/k8s/provider.go
@@ -176,10 +176,11 @@ func generateFromContainerPorts(serviceName string, pod *corev1.Pod, globalTags 
 	}
 
 	host := pod.GetStatus().GetPodIP()
+	podName := pod.GetMetadata().GetName()
 	port := int(*container.Ports[0].ContainerPort)
 
 	service := consul.ServiceInstance{
-		ID:    fmt.Sprintf("%s_%d", host, port),
+		ID:    fmt.Sprintf("%s_%d", podName, port),
 		Name:  serviceName,
 		Host:  host,
 		Port:  port,


### PR DESCRIPTION
Current consul-registration-hook behavior is different than what vaas-registration-hook provides, resulting in some tools removing VaaS backends due to a different instance name. This change fixes that issue by making Consul IDs the same as what VaaS expects. It also further eliminates the possibility to mismatch instances when an IP gets reassigned and the port is constant.