### PR TITLE
Add instance tag for VaaS integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ OS        := $(shell go env GOOS)
 BUILD_DIR := build
 LDFLAGS   := -X main.version=$(VERSION)
 
+CURRENT_DIR = $(shell pwd)
+BIN = $(CURRENT_DIR)/bin
 THIS_FILE := $(lastword $(MAKEFILE_LIST))
 .PHONY: all build build-linux package clean lint lint-deps test integration-test
 
@@ -25,11 +27,12 @@ clean:
 	rm -rf $(BUILD_DIR)
 
 lint: lint-deps
-	golangci-lint run --config=golangcilinter.yaml ./...
+	$(BIN)/golangci-lint --version
+	$(BIN)/golangci-lint run --config=golangcilinter.yaml ./...
 
 lint-deps:
 	@which golangci-lint > /dev/null || \
-		(go get -u github.com/golangci/golangci-lint/cmd/golangci-lint)
+		(curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(BIN) v1.30.0)
 
 test:
 	go test -v -coverprofile=coverage.txt -covermode=atomic ./...

--- a/k8s/provider_test.go
+++ b/k8s/provider_test.go
@@ -79,7 +79,7 @@ func TestIfReturnsServiceToRegisterIfAbleToCallKubernetesAPI(t *testing.T) {
 
 	service := services[0]
 
-	assert.Len(t, service.Tags, 0)
+	assert.Equal(t, []string{"instance:podName_8080"}, service.Tags)
 	assert.Equal(t, "192.0.2.2_8080", service.ID)
 	assert.Equal(t, "serviceName", service.Name)
 	assert.Equal(t, 8080, service.Port)
@@ -116,7 +116,7 @@ func TestIfReturnsServiceToRegisterWhenLapeledContainerIsSpecified(t *testing.T)
 
 	service := services[0]
 
-	assert.Len(t, service.Tags, 0)
+	assert.Equal(t, []string{"instance:podName_8181"}, service.Tags)
 	assert.Equal(t, "192.0.2.2_8181", service.ID)
 	assert.Equal(t, "serviceName", service.Name)
 	assert.Equal(t, 8181, service.Port)
@@ -152,7 +152,7 @@ func TestIfReturnsServiceToRegisterAppPortWhenNoLabelSpecified(t *testing.T) {
 
 	service := services[0]
 
-	assert.Len(t, service.Tags, 0)
+	assert.Equal(t, []string{"instance:podName_8080"}, service.Tags)
 	assert.Equal(t, "192.0.2.2_8080", service.ID)
 	assert.Equal(t, "serviceName", service.Name)
 	assert.Equal(t, 8080, service.Port)
@@ -232,7 +232,7 @@ func TestIfRetriesWhenInitialIPEmpty(t *testing.T) {
 
 	service := services[0]
 
-	assert.Len(t, service.Tags, 0)
+	assert.Equal(t, []string{"instance:podName_8080"}, service.Tags)
 	assert.Equal(t, "192.0.2.2_8080", service.ID)
 	assert.Equal(t, "serviceName", service.Name)
 	assert.Equal(t, 8080, service.Port)
@@ -246,21 +246,21 @@ var labelsAndAnnotationsTestCases = []struct {
 		pod: composeTestCasePod(
 			map[string]string{
 				"CONSUL_TAG_0": "KEY0: VALUE0"}),
-		expectedConsulTags: []string{"KEY0: VALUE0"},
+		expectedConsulTags: []string{"KEY0: VALUE0", "instance:podName_8080"},
 	},
 	{
 		pod: composeTestCasePod(
 			map[string]string{
 				"CONSUL_TAG_0": "KEY0: VALUE0",
 				"CONSUL_TAG_1": ""}),
-		expectedConsulTags: []string{"KEY0: VALUE0"},
+		expectedConsulTags: []string{"KEY0: VALUE0", "instance:podName_8080"},
 	},
 	{
 		pod: composeTestCasePod(
 			map[string]string{
 				"CONSUL_TAG_0": "KEY0: VALUE0",
 				"CONSUL_TAG_1": "KEY1: VALUE1"}),
-		expectedConsulTags: []string{"KEY0: VALUE0", "KEY1: VALUE1"},
+		expectedConsulTags: []string{"KEY0: VALUE0", "KEY1: VALUE1", "instance:podName_8080"},
 	},
 	{
 		pod: composeTestCasePod(
@@ -269,7 +269,7 @@ var labelsAndAnnotationsTestCases = []struct {
 				"CONSUL_TAG_1":   "KEY1: VALUE1",
 				"CONSUL_TAG_1_a": "KEY2: VALUE2",
 			}),
-		expectedConsulTags: []string{"KEY0: VALUE0", "KEY1: VALUE1", "KEY2: VALUE2"},
+		expectedConsulTags: []string{"KEY0: VALUE0", "KEY1: VALUE1", "KEY2: VALUE2", "instance:podName_8080"},
 	},
 	{
 		pod: composeTestCasePod(
@@ -278,7 +278,7 @@ var labelsAndAnnotationsTestCases = []struct {
 				"CONSUL_TAG_1":   "KEY0: VALUE0",
 				"CONSUL_TAG_1_a": "KEY2: VALUE2",
 			}),
-		expectedConsulTags: []string{"KEY0: VALUE0", "KEY0: VALUE0", "KEY2: VALUE2"},
+		expectedConsulTags: []string{"KEY0: VALUE0", "KEY0: VALUE0", "KEY2: VALUE2", "instance:podName_8080"},
 	},
 }
 
@@ -358,6 +358,7 @@ func TestIfConvertNodeFailureDomainTagsToConsulTags(t *testing.T) {
 
 func testPod() *corev1.Pod {
 	podIP := "192.0.2.2"
+	podName := "podName"
 
 	return &corev1.Pod{
 		Spec: &corev1.PodSpec{
@@ -377,6 +378,7 @@ func testPod() *corev1.Pod {
 		Metadata: &metav1.ObjectMeta{
 			Labels:      make(map[string]string),
 			Annotations: make(map[string]string),
+			Name: &podName,
 		},
 	}
 }


### PR DESCRIPTION
Add a new `instance` tag for VaaS to identify k8s instances consistently with vaas-registration-hook.