### PR TITLE
Generate instance tag when using port definitions

### DIFF
--- a/k8s/provider.go
+++ b/k8s/provider.go
@@ -216,6 +216,7 @@ func getContainerToRegister(pod *corev1.Pod) (*corev1.Container, error) {
 func generateFromPortDefinitions(serviceName string, portDefinitions *portDefinitions, pod *corev1.Pod, globalTags []string) ([]consul.ServiceInstance, error) {
 	var services []consul.ServiceInstance
 	host := pod.GetStatus().GetPodIP()
+	podName := pod.GetMetadata().GetName()
 	// TODO(tz) - provide container id with readiness probe
 	container := pod.Spec.Containers[0]
 
@@ -235,6 +236,7 @@ func generateFromPortDefinitions(serviceName string, portDefinitions *portDefini
 				Tags:  globalTags,
 			}
 			service.Tags = append(service.Tags, portDefinition.getTags()...)
+			service.Tags = append(service.Tags, createInstanceTag(podName, portDefinition.Port))
 			services = append(services, service)
 		} else if portDefinition.isProbe() {
 			// probe is taken from liveness probe of first container, it is assumet to match this one

--- a/k8s/provider_test.go
+++ b/k8s/provider_test.go
@@ -492,7 +492,7 @@ func TestCheckOneServiceFromWithProperTags(t *testing.T) {
 	expectedServices := []consul.ServiceInstance{
 		{
 			Tags: []string{
-				"a", "b", "c", "envoy",
+				"a", "b", "c", "envoy", "instance:podName_31000",
 			},
 		},
 	}
@@ -511,13 +511,13 @@ func TestShouldCheckMultipleServicesWithGlobalTagsCombinedAndWithPortSpecificTag
 	tags := []string{"a", "b", "c"}
 	expectedServices := []consul.ServiceInstance{
 		{
-			Tags: []string{"a", "b", "c"},
+			Tags: []string{"a", "b", "c", "instance:podName_31000"},
 		},
 		{
-			Tags: []string{"a", "b", "c", "secureConnection:true"},
+			Tags: []string{"a", "b", "c", "secureConnection:true", "instance:podName_31002"},
 		},
 		{
-			Tags: []string{"a", "b", "c", "service-port:31000", "frontend:generic-app", "envoy"},
+			Tags: []string{"a", "b", "c", "service-port:31000", "frontend:generic-app", "envoy", "instance:podName_31003"},
 		},
 	}
 


### PR DESCRIPTION
Generate `instance` tag when using port definitions to create Consul services.