### PR TITLE
Ignore Consul deregister err on K8S

### DIFF
--- a/cmd/consul-registration-hook/main.go
+++ b/cmd/consul-registration-hook/main.go
@@ -86,7 +86,7 @@ var commands = []cli.Command{
 					if len(deregisterServices) > 0 {
 						er := agent.Deregister(deregisterServices)
 						if er != nil {
-							return fmt.Errorf("error deregistering services : %s", err)
+							log.Printf("Error deregistering services : %s", er)
 						}
 					}
 					return agent.Register(services)


### PR DESCRIPTION
Since old Consul version (~v1.1.0) throws error on deregistering non existent services it should be ignored and processing should continue. Getting list of services from Consul first and then deciding if hook should deregister "-secured" postfixed instances is to much resource consuming